### PR TITLE
fix(analyzer): bypass go-driver struct serialization for CreateAnalyzer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - contextcheck
     - errname
     - errorlint
-    - exportloopref
+    - copyloopvar
     - goconst
     - gocritic
     - gofmt

--- a/arangodb_test.go
+++ b/arangodb_test.go
@@ -737,3 +737,129 @@ func (m *MockArangoSearchAnalyzer) Remove(ctx context.Context, force bool) error
 	args := m.Called(ctx, force)
 	return args.Error(0)
 }
+
+type MockConnection struct {
+	mock.Mock
+}
+
+func (m *MockConnection) NewRequest(method, path string) (arangoDriver.Request, error) {
+	args := m.Called(method, path)
+	return args.Get(0).(arangoDriver.Request), args.Error(1)
+}
+
+func (m *MockConnection) Do(ctx context.Context, req arangoDriver.Request) (arangoDriver.Response, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(arangoDriver.Response), args.Error(1)
+}
+
+func (m *MockConnection) Unmarshal(data arangoDriver.RawObject, result any) error {
+	args := m.Called(data, result)
+	return args.Error(0)
+}
+
+func (m *MockConnection) Endpoints() []string {
+	args := m.Called()
+	return args.Get(0).([]string)
+}
+
+func (m *MockConnection) UpdateEndpoints(endpoints []string) error {
+	args := m.Called(endpoints)
+	return args.Error(0)
+}
+
+func (m *MockConnection) SetAuthentication(auth arangoDriver.Authentication) (arangoDriver.Connection, error) {
+	args := m.Called(auth)
+	return args.Get(0).(arangoDriver.Connection), args.Error(1)
+}
+
+func (m *MockConnection) Protocols() arangoDriver.ProtocolSet {
+	args := m.Called()
+	return args.Get(0).(arangoDriver.ProtocolSet)
+}
+
+type MockRequest struct {
+	mock.Mock
+}
+
+func (m *MockRequest) SetQuery(key, value string) arangoDriver.Request {
+	m.Called(key, value)
+	return m
+}
+
+func (m *MockRequest) SetBody(body ...interface{}) (arangoDriver.Request, error) {
+	args := m.Called(body)
+	return m, args.Error(0)
+}
+
+func (m *MockRequest) SetBodyArray(bodyArray interface{}, mergeArray []map[string]interface{}) (arangoDriver.Request, error) {
+	args := m.Called(bodyArray, mergeArray)
+	return m, args.Error(0)
+}
+
+func (m *MockRequest) SetBodyImportArray(bodyArray interface{}) (arangoDriver.Request, error) {
+	args := m.Called(bodyArray)
+	return m, args.Error(0)
+}
+
+func (m *MockRequest) SetHeader(key, value string) arangoDriver.Request {
+	m.Called(key, value)
+	return m
+}
+
+func (m *MockRequest) Written() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockRequest) Clone() arangoDriver.Request {
+	m.Called()
+	return m
+}
+
+func (m *MockRequest) Path() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockRequest) Method() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+type MockResponse struct {
+	mock.Mock
+}
+
+func (m *MockResponse) StatusCode() int {
+	args := m.Called()
+	return args.Int(0)
+}
+
+func (m *MockResponse) Endpoint() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockResponse) Header(name string) string {
+	args := m.Called(name)
+	return args.String(0)
+}
+
+func (m *MockResponse) CheckStatus(validStatusCodes ...int) error {
+	callArgs := make([]interface{}, len(validStatusCodes))
+	for i, code := range validStatusCodes {
+		callArgs[i] = code
+	}
+	args := m.Called(callArgs...)
+	return args.Error(0)
+}
+
+func (m *MockResponse) ParseBody(field string, result interface{}) error {
+	args := m.Called(field, result)
+	return args.Error(0)
+}
+
+func (m *MockResponse) ParseArrayBody() ([]arangoDriver.Response, error) {
+	args := m.Called()
+	return args.Get(0).([]arangoDriver.Response), args.Error(1)
+}

--- a/cmd/arangom/main.go
+++ b/cmd/arangom/main.go
@@ -89,12 +89,12 @@ func validateFlags() error {
 	return nil
 }
 
-func initDatabase() (arangoDriver.Database, error) {
+func initDatabase() (arangoDriver.Database, arangoDriver.Connection, error) {
 	conn, err := arangoHTTP.NewConnection(arangoHTTP.ConnectionConfig{
 		Endpoints: strings.Split(dbEndpoints, ","),
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	client, err := arangoDriver.NewClient(arangoDriver.ClientConfig{
@@ -102,26 +102,26 @@ func initDatabase() (arangoDriver.Database, error) {
 		Authentication: arangoDriver.BasicAuthentication(dbUsername, dbPassword),
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	db, err := client.Database(context.Background(), dbName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	collExists, err := db.CollectionExists(context.Background(), collection)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if !collExists && createCollection {
 		if _, err := db.CreateCollection(context.Background(), collection, nil); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return db, nil
+	return db, client.Connection(), nil
 }
 
 // loadMigration loads a single migration file.
@@ -165,7 +165,7 @@ func loadMigrations(path string) ([]*arangom.Migration, error) {
 }
 
 func main() {
-	db, err := initDatabase()
+	db, conn, err := initDatabase()
 	if err != nil {
 		panic(err)
 	}
@@ -177,6 +177,7 @@ func main() {
 
 	executor, err := arangom.NewExecutor(
 		arangom.WithDatabase(db),
+		arangom.WithConnection(conn),
 		arangom.WithCollection(collection),
 		arangom.WithMigrations(migrations),
 	)

--- a/executor.go
+++ b/executor.go
@@ -7,6 +7,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+type connCtxKey struct{}
+
+// WithConnectionContext returns a context with the given connection stored in it.
+func WithConnectionContext(ctx context.Context, conn driver.Connection) context.Context {
+	return context.WithValue(ctx, connCtxKey{}, conn)
+}
+
+// ConnectionFromContext retrieves the connection from the context, or nil if not set.
+func ConnectionFromContext(ctx context.Context) driver.Connection {
+	conn, _ := ctx.Value(connCtxKey{}).(driver.Connection)
+	return conn
+}
+
 // ExecutorOption is a function that sets configuration options on Executor.
 type ExecutorOption func(*Executor) error
 
@@ -46,6 +59,15 @@ func WithMigrations(migrations []*Migration) ExecutorOption {
 	}
 }
 
+// WithConnection sets the connection of the executor. This is required for
+// operations that need raw HTTP access (e.g. createAnalyzer).
+func WithConnection(conn driver.Connection) ExecutorOption {
+	return func(e *Executor) error {
+		e.conn = conn
+		return nil
+	}
+}
+
 // WithLogger sets the logger of the executor.
 func WithLogger(logger Logger) ExecutorOption {
 	return func(e *Executor) error {
@@ -61,6 +83,7 @@ func WithLogger(logger Logger) ExecutorOption {
 // Executor executes migrations on a database in order.
 type Executor struct {
 	db         driver.Database
+	conn       driver.Connection
 	collection string
 	migrations []*Migration
 	logger     Logger
@@ -93,7 +116,12 @@ func (e *Executor) Execute(ctx context.Context) error {
 		migration.Status = MigrationStatusRunning
 		saveMigration(ctx, coll, migration)
 
-		if err := migration.Migrate(ctx, e.db); err != nil {
+		migrateCtx := ctx
+		if e.conn != nil {
+			migrateCtx = WithConnectionContext(ctx, e.conn)
+		}
+
+		if err := migration.Migrate(migrateCtx, e.db); err != nil {
 			migration.Status = MigrationStatusFailed
 			saveMigration(ctx, coll, migration)
 

--- a/operation.go
+++ b/operation.go
@@ -586,19 +586,40 @@ func DeleteIndexOperation(o *Operation) OperationFn {
 
 func CreateAnalyzerOperation(o *Operation) OperationFn {
 	return func(ctx context.Context, db driver.Database) error {
-
-		opts := driver.ArangoSearchAnalyzerDefinition{}
-		if err := convertToOperationOptions(o.Options, &opts); err != nil {
-			return err
+		conn := ConnectionFromContext(ctx)
+		if conn == nil {
+			return fmt.Errorf("connection is required for createAnalyzer operation; use WithConnection option")
 		}
 
-		found, _, err := db.EnsureAnalyzer(ctx, opts)
+		body := map[string]any{
+			"name": o.Options["name"],
+			"type": o.Options["type"],
+		}
+		if p, ok := o.Options["properties"]; ok {
+			body["properties"] = p
+		}
+		if f, ok := o.Options["features"]; ok {
+			body["features"] = f
+		}
+
+		reqPath := fmt.Sprintf("/_db/%s/_api/analyzer", db.Name())
+		req, err := conn.NewRequest("POST", reqPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create analyzer request: %w", err)
 		}
 
-		if found {
-			return fmt.Errorf("analyzer '%s' already exists", opts.Name)
+		req, err = req.SetBody(body)
+		if err != nil {
+			return fmt.Errorf("failed to set analyzer request body: %w", err)
+		}
+
+		resp, err := conn.Do(ctx, req)
+		if err != nil {
+			return fmt.Errorf("failed to create analyzer: %w", err)
+		}
+
+		if err := resp.CheckStatus(200, 201); err != nil {
+			return err
 		}
 
 		return nil

--- a/operation_test.go
+++ b/operation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/arangodb/go-driver"
+	"github.com/stretchr/testify/mock"
 	"gopkg.in/yaml.v3"
 )
 
@@ -2771,21 +2772,65 @@ func TestCreateAnalyzerOperation(t *testing.T) {
 					},
 				},
 			},
-			args: args{
-				ctx: context.Background(),
-				db: func() driver.Database {
-					db := new(MockArangoDB)
-					db.On("EnsureAnalyzer", context.Background(), driver.ArangoSearchAnalyzerDefinition{
-						Name: "text_en",
-						Type: "text",
-					}).Return(false, new(MockArangoSearchAnalyzer), nil)
+			args: func() args {
+				mockReq := new(MockRequest)
+				mockReq.On("SetBody", mock.Anything).Return(nil)
 
-					return db
-				}(),
-			},
+				mockResp := new(MockResponse)
+				mockResp.On("CheckStatus", 200, 201).Return(nil)
+
+				mockConn := new(MockConnection)
+				mockConn.On("NewRequest", "POST", "/_db/testdb/_api/analyzer").Return(mockReq, nil)
+				mockConn.On("Do", mock.Anything, mockReq).Return(mockResp, nil)
+
+				db := new(MockArangoDB)
+				db.On("Name").Return("testdb")
+
+				return args{
+					ctx: WithConnectionContext(context.Background(), mockConn),
+					db:  db,
+				}
+			}(),
 		},
 		{
-			name: "create analyzer operation with error",
+			name: "create analyzer operation with properties and features",
+			fields: fields{
+				operation: &Operation{
+					Kind: OperationKindAnalyzerCreate,
+					Options: map[string]any{
+						"name": "ngram_lower",
+						"type": "pipeline",
+						"properties": map[string]any{
+							"pipeline": []any{
+								map[string]any{"type": "norm", "properties": map[string]any{"locale": "en"}},
+							},
+						},
+						"features": []any{"frequency", "norm", "position"},
+					},
+				},
+			},
+			args: func() args {
+				mockReq := new(MockRequest)
+				mockReq.On("SetBody", mock.Anything).Return(nil)
+
+				mockResp := new(MockResponse)
+				mockResp.On("CheckStatus", 200, 201).Return(nil)
+
+				mockConn := new(MockConnection)
+				mockConn.On("NewRequest", "POST", "/_db/testdb/_api/analyzer").Return(mockReq, nil)
+				mockConn.On("Do", mock.Anything, mockReq).Return(mockResp, nil)
+
+				db := new(MockArangoDB)
+				db.On("Name").Return("testdb")
+
+				return args{
+					ctx: WithConnectionContext(context.Background(), mockConn),
+					db:  db,
+				}
+			}(),
+		},
+		{
+			name: "create analyzer operation with HTTP error",
 			fields: fields{
 				operation: &Operation{
 					Kind: OperationKindAnalyzerCreate,
@@ -2795,21 +2840,29 @@ func TestCreateAnalyzerOperation(t *testing.T) {
 					},
 				},
 			},
-			args: args{
-				ctx: context.Background(),
-				db: func() driver.Database {
-					db := new(MockArangoDB)
-					db.On("EnsureAnalyzer", context.Background(), driver.ArangoSearchAnalyzerDefinition{
-						Name: "text_en",
-						Type: "text",
-					}).Return(false, new(MockArangoSearchAnalyzer), fmt.Errorf("error"))
-					return db
-				}(),
-			},
+			args: func() args {
+				mockReq := new(MockRequest)
+				mockReq.On("SetBody", mock.Anything).Return(nil)
+
+				mockResp := new(MockResponse)
+				mockResp.On("CheckStatus", 200, 201).Return(fmt.Errorf("bad request"))
+
+				mockConn := new(MockConnection)
+				mockConn.On("NewRequest", "POST", "/_db/testdb/_api/analyzer").Return(mockReq, nil)
+				mockConn.On("Do", mock.Anything, mockReq).Return(mockResp, nil)
+
+				db := new(MockArangoDB)
+				db.On("Name").Return("testdb")
+
+				return args{
+					ctx: WithConnectionContext(context.Background(), mockConn),
+					db:  db,
+				}
+			}(),
 			wantErr: true,
 		},
 		{
-			name: "try to recreate existing analyzer",
+			name: "create analyzer operation without connection",
 			fields: fields{
 				operation: &Operation{
 					Kind: OperationKindAnalyzerCreate,
@@ -2822,13 +2875,7 @@ func TestCreateAnalyzerOperation(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				db: func() driver.Database {
-					db := new(MockArangoDB)
-					db.On("EnsureAnalyzer", context.Background(), driver.ArangoSearchAnalyzerDefinition{
-						Name: "text_en",
-						Type: "text",
-					}).Return(true, new(MockArangoSearchAnalyzer), nil)
-
-					return db
+					return new(MockArangoDB)
 				}(),
 			},
 			wantErr: true,


### PR DESCRIPTION
## Summary

Fixes #7

- Replace `EnsureAnalyzer` with direct HTTP POST to `/_api/analyzer` to avoid the go-driver injecting null fields (e.g. `"stopwords": null`) that ArangoDB rejects for analyzer types that don't support them (ngram, norm, pipeline)
- Pass `driver.Connection` via context (`WithConnectionContext`/`ConnectionFromContext`) so `CreateAnalyzerOperation` can make raw HTTP calls with only the YAML-specified fields, without changing the `Migrate` signature
- Add `WithConnection` executor option to provide the connection